### PR TITLE
Patch 1.2.3, error 400 detection (2FA code)

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.2",
+  "version": "1.2.3",
   "name": "Lucca",
   "type": "konnector",
   "language": "node",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-konnector-lucca",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "",
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,25 @@ async function start(fields) {
   await checkLoginInfos(fields)
   await logIn(fields)
   const payslips = await getPayslips()
+
+  // Some companies activate 2FA 6 digits to download files, not implemented
+  // We test it here
+  if (payslips.length > 0) {
+    try {
+      await request(payslips[0].fileurl)
+    } catch (e) {
+      if (
+        e.statusCode === 400 &&
+        e.message.includes('6 digit security code has been activated')
+      ) {
+        log('error', e)
+        log('error', 'Not implemented in konnector')
+        throw 'USER_ACTION_NEEDED.TWOFA_NEEDED'
+      } else {
+        throw e
+      }
+    }
+  }
   await saveFiles(payslips, fields)
 }
 


### PR DESCRIPTION
Hey @sebdalink 

I suited up a fix for companies that enabled 2FA on file download.
This patch add a detection step just before the saveFiles and don't launch it if code is needed. It should avoid to create pdf files containing only the html error on cozy for this kind of account.

Please review and merge.
I can publish after that if you want.

Lucas